### PR TITLE
fixed max recurion bug

### DIFF
--- a/gamebook/game_input.py
+++ b/gamebook/game_input.py
@@ -9,12 +9,12 @@ class Input(object):
     @property
     def interface(self) -> InputInterface:
         """ reference to the InputInterface object"""
-        return self.interface
+        return self._interface
 
     @interface.setter
-    def interface(self, interface: InputInterface) -> None:
+    def interface(self, new_interface: InputInterface) -> None:
         """replace the interface at runtime"""
-        self.interface = interface
+        self._interface = new_interface
 
     def input(self, prompt: str):
         return self.interface.input(prompt)

--- a/gamebook/output.py
+++ b/gamebook/output.py
@@ -9,12 +9,12 @@ class Output(object):
     @property
     def interface(self) -> OutputInterface:
         """ reference to the OutputInterface object"""
-        return self.interface
+        return self._interface
 
     @interface.setter
-    def interface(self, interface: OutputInterface) -> None:
+    def interface(self, new_interface: OutputInterface) -> None:
         """replace the interface at runtime"""
-        self.interface = interface
+        self._interface = new_interface
 
     def output(self, content: str):
         self.interface.output(content)

--- a/gamebook/terminal_input.py
+++ b/gamebook/terminal_input.py
@@ -1,9 +1,9 @@
-from gamebook.game_input import Input
+from gamebook.input_interface import InputInterface
 from gamebook.constants import exit_user_input_request, input_prompt
 from gamebook.constants import user_inputs_request_format
 
 
-class TerminalInput(Input):
+class TerminalInput(InputInterface):
 
     def input(self, prompt: str) -> str:
         data = input(prompt)


### PR DESCRIPTION
the new `input` and `output` versions had a bug that creates a max recursion error.

terminal output:

Traceback (most recent call last):
  File "example.py", line 99, in <module>
  File "example.py", line 94, in main
    gm = GameManager(scenes_list, "terminal")
  File "game_manager.py", line 25, in __init__ 
    input_formats = {"terminal": TerminalInput()}
TypeError: __init__() missing 1 required positional argument: 'interface'

  File "example.py", line 99, in <module>
    main()
  File "example.py", line 94, in main
    gm = GameManager(scenes_list, "terminal")
  File "game_manager.py", line 26, in __init__ 
    self.output_instance = Output(output_formats.get(format, "terminal"))
  File "output.py", line 7, in __init__        
    self.interface = interface
  File "output.py", line 17, in interface      
    self.interface = interface
  File "output.py", line 17, in interface      
    self.interface = interface
  File "output.py", line 17, in interface      
    self.interface = interface
  [Previous line repeated 991 more times]
RecursionError: maximum recursion depth exceeded